### PR TITLE
Installing types for Helmet

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2548,6 +2548,15 @@
         "@types/react": "*"
       }
     },
+    "@types/react-helmet": {
+      "version": "6.1.5",
+      "resolved": "https://registry.npmjs.org/@types/react-helmet/-/react-helmet-6.1.5.tgz",
+      "integrity": "sha512-/ICuy7OHZxR0YCAZLNg9r7I9aijWUWvxaPR6uTuyxe8tAj5RL4Sw1+R6NhXUtOsarkGYPmaHdBDvuXh2DIN/uA==",
+      "dev": true,
+      "requires": {
+        "@types/react": "*"
+      }
+    },
     "@types/react-router": {
       "version": "5.1.17",
       "resolved": "https://registry.npmjs.org/@types/react-router/-/react-router-5.1.17.tgz",

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "@types/node": "^16.7.1",
     "@types/react": "^17.0.19",
     "@types/react-dom": "^17.0.14",
+    "@types/react-helmet": "^6.1.5",
     "@types/react-router-dom": "^5.1.8",
     "@typescript-eslint/eslint-plugin": "^4.29.3",
     "@typescript-eslint/parser": "^4.29.3",


### PR DESCRIPTION
Deploying to GH pages results in a `Helmet' cannot be used as a JSX component` error. Installing its types might help resolve the issue as suggested in [this SO thread](https://stackoverflow.com/questions/65255300/helmet-is-not-a-valid-jsx-element)